### PR TITLE
Bukkit is on 1.0.1-R1, not 0.0.1-SNAPSHOT.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,13 +55,13 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>1.0.1-R1</version>
             <type>jar</type>
         </dependency>
 	<dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>1.0.1-R1</version>
             <type>jar</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
0.0.1-SNAPSHOT was last used with... before 1.8.1-R4? >_>
