### PR TITLE
Don't build against a SNAPSHOT API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.5.2-R0.1-SNAPSHOT</version>
+            <version>1.5.2-R0.1</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
This breaks new builds or CI builds, since Bukkit doesn't seem to host the SNAPSHOT version anymore.